### PR TITLE
[Feature] auto select file contents after opening it.

### DIFF
--- a/Image2Base64.py
+++ b/Image2Base64.py
@@ -19,6 +19,7 @@ class I2b64Change(sublime_plugin.TextCommand):
         view = self.view
         view.replace(edit, sublime.Region(0, view.size()), image)
         view.set_read_only(True)
+	view.run_command("select_all")
 
 
 class I2b64Panel(sublime_plugin.TextCommand):


### PR DESCRIPTION
After opening the file, the first thing a user will do is select all of it's
content to copy it. Why not we do it for them!

We would not like to copy the content to clipboard automatically as it would
create unwanted confusion and frustration if someone clicks on an image file
in sidebar by mistake.
